### PR TITLE
Correction

### DIFF
--- a/src/framework/annotations/Field.java
+++ b/src/framework/annotations/Field.java
@@ -1,0 +1,9 @@
+package framework.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Field {
+    String name();
+}


### PR DESCRIPTION
Correction d'oubli : ajout d'annotation pour les attributs de classe qui permet à la construction d'objet en paramètre de fonction de ne pas seulement utiliser le nom direct de l'attribut en question. 